### PR TITLE
Fix OpenMP check treating Clang-CL as MSVC

### DIFF
--- a/cmake/sail_check_openmp.cmake
+++ b/cmake/sail_check_openmp.cmake
@@ -10,7 +10,7 @@ function(sail_check_openmp)
         # The default OpenMP implementation in MSVC 2022 still supports 2.0,
         # so switch to the LLVM option with OpenMP 3.1.
         #
-        if (MSVC)
+        if (MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             set(SAIL_OPENMP_FLAGS "/openmp:llvm" CACHE INTERNAL "")
         else()
             set(SAIL_OPENMP_FLAGS ${OpenMP_C_FLAGS} CACHE INTERNAL "")

--- a/cmake/sail_check_openmp.cmake
+++ b/cmake/sail_check_openmp.cmake
@@ -10,7 +10,7 @@ function(sail_check_openmp)
         # The default OpenMP implementation in MSVC 2022 still supports 2.0,
         # so switch to the LLVM option with OpenMP 3.1.
         #
-        if (MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        if (MSVC AND NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
             set(SAIL_OPENMP_FLAGS "/openmp:llvm" CACHE INTERNAL "")
         else()
             set(SAIL_OPENMP_FLAGS ${OpenMP_C_FLAGS} CACHE INTERNAL "")


### PR DESCRIPTION
When building with Clang-CL, the OpenMP cmake test sets the flags for MSVC (/openmp:llvm). This is not a valid argument for Clang-CL and the test fails. Only setting the MSVC flags if the compiler ID isn't Clang fixes this.