### PR TITLE
CMake UNIX Platform Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,10 +193,6 @@ if (WIN32)
     set(SAIL_WIN32 ON)
 endif()
 
-if (UNIX)
-    set(SAIL_UNIX ON)
-endif()
-
 if (MINGW)
     set(SAIL_MINGW ON)
 endif()
@@ -207,6 +203,10 @@ endif()
 
 if (APPLE)
     set(SAIL_APPLE ON)
+endif()
+
+if (UNIX)
+    set(SAIL_UNIX ON)
 endif()
 
 # Codecs & icons paths


### PR DESCRIPTION
This simple commit could solve some problems later down the road. In at least newer CMake versions, checking if the platform is UNIX like you had can cause Apple and Cygwin targets to be a miss since both count as UNIX in CMake.

See here for more information: https://cmake.org/cmake/help/latest/variable/UNIX.html