### PR TITLE
Fixing build issue with Linux/Clang/C++23

### DIFF
--- a/src/bindings/sail-c++/io_base.cpp
+++ b/src/bindings/sail-c++/io_base.cpp
@@ -33,6 +33,10 @@ io_base::io_base(struct sail_io *sail_io)
 {
 }
 
+io_base::~io_base()
+{
+}
+
 int io_base::features() const
 {
     return d->sail_io_wrapper->features;

--- a/src/bindings/sail-c++/io_base.h
+++ b/src/bindings/sail-c++/io_base.h
@@ -61,6 +61,8 @@ public:
      */
     explicit io_base(struct sail_io *sail_io);
 
+    ~io_base();
+
     /*
      * Returns the I/O stream features. See SailIoFeature.
      */


### PR DESCRIPTION
io_base doesn't have a declared destructor, and gets an automatically generated one. This automatic destructor tries to destruct the pimpl unique pointer and causes a compilation failure.

Fix: add an explicit destructor with an empty implementation in the cpp file.