### PR TITLE
Add mention of available Ubuntu and Arch Linux packages + add BUILD_TESTING to the list of CMake options

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -27,6 +27,8 @@ vcpkg install sail
 - `SAIL_ONLY_CODECS="a;b;c"` - Forcefully enable only the codecs specified in this ';'-separated list and disable the rest. If an enabled codec fails to find its dependencies, the configuration process fails. One can also specify not just individual codecs but codec groups by their priority like that: highest-priority;xbm. Default: empty list
 - `SAIL_OPENMP_SCHEDULE="dynamic"` - OpenMP scheduling algorithm. Default: dynamic
 
+- `BUILD_TESTING=ON|OFF` - Enable generation of tests using CTest. Default: `ON`
+
 ### Windows
 
 #### Tested environments
@@ -88,6 +90,13 @@ brew upgrade sail
 
 - LUbuntu 18.04 64-bit
 - LUbuntu 20.04 64-bit
+
+#### Package Managers
+
+SAIL is not always available in official distro repositories. Here is an incomplete list of available packages for various distributions:
+
+- Ubuntu 24.04 - `sudo apt-get install sail-codecs libsail-dev libsail-common-dev libsail-manip-dev libsail-c++-dev`
+- Arch User Repository - [`sail-img`](https://aur.archlinux.org/packages/sail-img)
 
 #### Build requirements
 


### PR DESCRIPTION
Hi, today I was updating the AUR package and I noticed that tests were always being built and there is no option to disable them. I have never used CTest so when I looked at the root CMakeLists.txt file, i thought there was a mistake and I wanted to add something like a `SAIL_BUILD_TESTS` option. Thankfully I checked closed PRs and saw a pull request that tried to do the same thing.

I know that the option is probably not listed in the CMake options overview in `BUILDING.md`, because it's a built-in CMake option and not specific to this project, however I still think it's worth mentioning.

I also listed available Ubuntu and AUR packages of this project. I also checked Debian, Fedora and NixOS repositories, but could not find any related packages there.